### PR TITLE
Fix deprecation issue with collections.abc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 script: python3 -m pytest

--- a/autovalue/__init__.py
+++ b/autovalue/__init__.py
@@ -1,4 +1,4 @@
-from collections import Hashable
+from collections.abc import Hashable
 from functools import wraps
 from inspect import getmembers, signature
 


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated since Python 3.3,
and in 3.9 it will stop working